### PR TITLE
Fixes for setup.py and shiny for python

### DIFF
--- a/build_pkg_setup.py
+++ b/build_pkg_setup.py
@@ -14,7 +14,7 @@ dash_pkgs = @PKG_REQUIREMENTS_DASH@
 jupyter_pkgs = @PKG_REQUIREMENTS_JUPYTER@
 streamlit_pkgs = @PKG_REQUIREMENTS_STREAMLIT@
 shiny_pkgs = @PKG_REQUIREMENTS_SHINY@
-rstudio_pkgs = @PKG_REQUIREMENTS_SHINY@
+rstudio_pkgs = @PKG_REQUIREMENTS_RSTUDIO@
 
 setup(
     name='canvasxpress',
@@ -81,12 +81,12 @@ def get_version() -> str:
 
 def get_requirements() -> dict:
     packages = {
-        "core": [],
-        "dash": [],
-        "streamlit": [],
-        "jupyter": [],
-        "shiny": [],
-        "rstudio": [],
+        "# core": [],
+        "# dash": [],
+        "# streamlit": [],
+        "# jupyter": [],
+        "# shiny": [],
+        "# rstudio": [],
     }
 
     with open("requirements.txt") as reqs_file:
@@ -94,7 +94,7 @@ def get_requirements() -> dict:
         topic = topics[0]
         requirements_text = reqs_file.read()
         for line in requirements_text.splitlines():
-            candidate = line.replace("#", "").strip()
+            candidate = line.strip()
             if not line:
                 continue
 
@@ -115,12 +115,12 @@ def get_description() -> str:
 if __name__ == "__main__":
     package_version = get_version()
     packages = get_requirements()
-    package_requirements_core = ",\n    ".join(packages["core"])
-    package_requirements_dash = ",\n    ".join(packages["dash"])
-    package_requirements_streamlit = ",\n    ".join(packages["streamlit"])
-    package_requirements_jupyter = ",\n    ".join(packages["jupyter"])
-    package_requirements_shiny = ",\n    ".join(packages["shiny"])
-    package_requirements_rstudio = ",\n    ".join(packages["rstudio"])
+    package_requirements_core = ",\n    ".join(packages["# core"])
+    package_requirements_dash = ",\n    ".join(packages["# dash"])
+    package_requirements_streamlit = ",\n    ".join(packages["# streamlit"])
+    package_requirements_jupyter = ",\n    ".join(packages["# jupyter"])
+    package_requirements_shiny = ",\n    ".join(packages["# shiny"])
+    package_requirements_rstudio = ",\n    ".join(packages["# rstudio"])
     python_version = python_version()
 
     setup_instructions = setup_instructions_template.replace(

--- a/canvasxpress/render/json.py
+++ b/canvasxpress/render/json.py
@@ -4,8 +4,7 @@ from typing import Any, Union, List
 from canvasxpress.canvas import CanvasXpress
 from canvasxpress.render.base import CXRenderable
 
-JSON_TEMPLATE: str = (
-    """
+JSON_TEMPLATE: str = """
 {
     "renderTo": "@renderTo@",
     "data": @data@,
@@ -17,7 +16,6 @@ JSON_TEMPLATE: str = (
     "height": @height@
 }
 """.strip()
-)
 
 
 class CXJSON(CXRenderable):

--- a/plotly/cxdash/src/lib/components/CXDashElement.react.js
+++ b/plotly/cxdash/src/lib/components/CXDashElement.react.js
@@ -51,9 +51,9 @@ export default class CXDashElement extends Component {
         const dom_rsrc_id = "CXDashElementIncludeCSS";
         if (!document.getElementById(dom_rsrc_id)) {
             var head = document.getElementsByTagName("head")[0];
-            var s = document.createElement("style");
+            var s = document.createElement("link");
             s.type = "text/css";
-            s.src = resource_url;
+            s.href = resource_url;
             s.id = dom_rsrc_id;
             head.appendChild(s);
         }

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ requests>=2
 Deprecated>=1.2.12
 
 # jupyter
+jupyter
 IPython>=7
 beautifulsoup4>=4
 htmlmin>=0.1.12

--- a/tests/unit/test_CXImage.py
+++ b/tests/unit/test_CXImage.py
@@ -120,9 +120,9 @@ def test_cx_converst_to_image_base64():
 
 def test_render_html_as_image():
     images_found = render_html_as_image(
-        "https://canvasxpress.org/examples/network-3.html",
+        "https://canvasxpress.org/examples/area-1.html",
         format=PNG_IMAGE,
     )
     assert len(images_found) == 1
-    assert images_found[0]["id"] == "network3"
+    assert images_found[0]["id"] == "area1"
 


### PR DESCRIPTION
1.  setup.py build did not properly reference 3rd party package targets.
2.  shiny for python has a bug that prevents proper header inclusion of CX links.