### PR TITLE
Fix Plotly Dash build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,8 +77,19 @@ jobs:
       - run:
           name: Install Node and NPM for Dash and General Python
           command: |
-            apt-get -yq install --fix-missing nodejs
-            apt-get -yq install --fix-missing npm
+            # Configure Node 22 repository config
+            cd /tmp
+            curl -fsSL https://deb.nodesource.com/setup_16.x -o nodesource_setup.sh
+            chmod +x ./nodesource_setup.sh
+            ./nodesource_setup.sh
+
+            # Install Node
+            apt-get clean
+            apt-get autoclean
+            apt-get autoremove
+
+            apt-get install -yqf nodejs
+
             node --version
             npm --version
 
@@ -95,30 +106,42 @@ jobs:
 
             #  Ensure the presence of a virtual environment
             if ! [[ -d ./venv ]] ; then
-                python3 -m venv ./venv
+            python3 -m venv ./venv
             fi
             source ./venv/bin/activate
 
             # Ensure that essential project utilities are available
+            echo "Install Python components"
             pip install -U pip setuptools wheel
             pip install -U -r requirements.txt
 
+            echo "Install CanvasXpress NodeJS components"
             npm install canvasxpress
             npm install canvasxpress-react
 
+            echo "Run build"
             npm run build
             cp -R ./cxdash ../../
 
       - run:
           name: Install Node and NPM for Streamlit
           command: |
-            curl -sL https://deb.nodesource.com/setup_20.x -o setup_nodejs.sh
-            sh ./setup_nodejs.sh
-            apt update
-            apt install -yq --fix-missing nodejs
+            # Configure Node 20 repository config
+            cd /tmp
+            curl -fsSL https://deb.nodesource.com/setup_20.x -o nodesource_setup.sh
+            chmod +x ./nodesource_setup.sh
+            ./nodesource_setup.sh
+
+            # Install Node
+            apt-get clean
+            apt-get autoclean
+            apt-get autoremove
+
+            apt-get install -yqf nodejs
+            npm cache clear --force
+
             node --version
             npm --version
-            npm cache clear --force
 
       - run:
           name: Generate Streamlit Component
@@ -296,8 +319,19 @@ jobs:
       - run:
           name: Install Node and NPM for Dash and General Python
           command: |
-            apt-get -yq install --fix-missing nodejs
-            apt-get -yq install --fix-missing npm
+            # Configure Node 22 repository config
+            cd /tmp
+            curl -fsSL https://deb.nodesource.com/setup_16.x -o nodesource_setup.sh
+            chmod +x ./nodesource_setup.sh
+            ./nodesource_setup.sh
+
+            # Install Node
+            apt-get clean
+            apt-get autoclean
+            apt-get autoremove
+
+            apt-get install -yqf nodejs
+
             node --version
             npm --version
 
@@ -314,30 +348,42 @@ jobs:
 
             #  Ensure the presence of a virtual environment
             if ! [[ -d ./venv ]] ; then
-                python3 -m venv ./venv
+            python3 -m venv ./venv
             fi
             source ./venv/bin/activate
 
             # Ensure that essential project utilities are available
+            echo "Install Python components"
             pip install -U pip setuptools wheel
             pip install -U -r requirements.txt
 
+            echo "Install CanvasXpress NodeJS components"
             npm install canvasxpress
             npm install canvasxpress-react
 
+            echo "Run build"
             npm run build
             cp -R ./cxdash ../../
 
       - run:
           name: Install Node and NPM for Streamlit
           command: |
-            curl -sL https://deb.nodesource.com/setup_20.x -o setup_nodejs.sh
-            sh ./setup_nodejs.sh
-            apt update
-            apt install -yq --fix-missing nodejs
+            # Configure Node 20 repository config
+            cd /tmp
+            curl -fsSL https://deb.nodesource.com/setup_20.x -o nodesource_setup.sh
+            chmod +x ./nodesource_setup.sh
+            ./nodesource_setup.sh
+
+            # Install Node
+            apt-get clean
+            apt-get autoclean
+            apt-get autoremove
+
+            apt-get install -yqf nodejs
+            npm cache clear --force
+
             node --version
             npm --version
-            npm cache clear --force
 
       - run:
           name: Generate Streamlit Component
@@ -464,8 +510,19 @@ jobs:
       - run:
           name: Install Node and NPM for Dash and General Python
           command: |
-            apt-get -yq install --fix-missing nodejs
-            apt-get -yq install --fix-missing npm
+            # Configure Node 22 repository config
+            cd /tmp
+            curl -fsSL https://deb.nodesource.com/setup_16.x -o nodesource_setup.sh
+            chmod +x ./nodesource_setup.sh
+            ./nodesource_setup.sh
+
+            # Install Node
+            apt-get clean
+            apt-get autoclean
+            apt-get autoremove
+
+            apt-get install -yqf nodejs
+
             node --version
             npm --version
 
@@ -482,30 +539,42 @@ jobs:
 
             #  Ensure the presence of a virtual environment
             if ! [[ -d ./venv ]] ; then
-                python3 -m venv ./venv
+            python3 -m venv ./venv
             fi
             source ./venv/bin/activate
 
             # Ensure that essential project utilities are available
+            echo "Install Python components"
             pip install -U pip setuptools wheel
             pip install -U -r requirements.txt
 
+            echo "Install CanvasXpress NodeJS components"
             npm install canvasxpress
             npm install canvasxpress-react
 
+            echo "Run build"
             npm run build
             cp -R ./cxdash ../../
 
       - run:
           name: Install Node and NPM for Streamlit
           command: |
-            curl -sL https://deb.nodesource.com/setup_20.x -o setup_nodejs.sh
-            sh ./setup_nodejs.sh
-            apt update
-            apt install -yq --fix-missing nodejs
+            # Configure Node 20 repository config
+            cd /tmp
+            curl -fsSL https://deb.nodesource.com/setup_20.x -o nodesource_setup.sh
+            chmod +x ./nodesource_setup.sh
+            ./nodesource_setup.sh
+
+            # Install Node
+            apt-get clean
+            apt-get autoclean
+            apt-get autoremove
+
+            apt-get install -yqf nodejs
+            npm cache clear --force
+
             node --version
             npm --version
-            npm cache clear --force
 
       - run:
           name: Generate Streamlit Component

--- a/canvasxpress/canvas.py
+++ b/canvasxpress/canvas.py
@@ -915,7 +915,7 @@ class CanvasXpress(CXHtmlConvertable):
 
         # Support unique data without JSON data structure
         if canvasxpress["data"].get("raw"):
-            canvasxpress["data"] = canvasxpress["data"]["raw"]
+            canvasxpress["data"] = str(canvasxpress["data"]["raw"])
 
         cx_js = render_from_template(
             _CX_JS_TEMPLATE,

--- a/canvasxpress/render/popup.py
+++ b/canvasxpress/render/popup.py
@@ -1,19 +1,17 @@
-import uuid
 import os
-from copy import deepcopy
 import tempfile
+import uuid
+import webbrowser
+from copy import deepcopy
 from time import sleep
 from typing import Any, Union, List
-import webbrowser
 
 from canvasxpress.canvas import CanvasXpress
 from canvasxpress.render.base import CXRenderable
 
 _cx_fx_template = """
 <script type="text/javascript">
-    onReady(function () {
-        @code@
-    })
+    @code@
 </script>
 """
 
@@ -39,19 +37,19 @@ _cx_html_template = """
                 href='@css_url@' 
                 rel='stylesheet' 
                 type='text/css'
+                referrerpolicy='origin-when-cross-origin'
         />
         <script 
                 src='@js_url@' 
                 type='text/javascript'>
+                referrerpolicy='origin-when-cross-origin'
         </script>
-
-        <!-- 2. Include script to initialize object -->
-        @js_functions@
-
     </head>
     <body>
         <!-- 3. DOM element where the visualization will be displayed -->
         @canvases@
+        <!-- 2. Include script to initialize object -->
+        @js_functions@
      </body>
 </html>
 """

--- a/plotly/cxdash/package.json
+++ b/plotly/cxdash/package.json
@@ -1,61 +1,61 @@
 {
-  "name": "cxdash",
-  "version": "1.1.0",
-  "description": "CanvasXpress for Plotly Dash",
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/https://github.com/docinfosci/canvasxpress-python/cxdash.git"
-  },
-  "bugs": {
-    "url": "https://github.com/https://github.com/docinfosci/canvasxpress-python/cxdash/issues"
-  },
-  "homepage": "https://github.com/https://github.com/docinfosci/canvasxpress-python/cxdash",
-  "main": "build/index.js",
-  "scripts": {
-    "start": "webpack-serve --config ./webpack.serve.config.js --open",
-    "validate-init": "python _validate_init.py",
-    "prepublishOnly": "npm run validate-init",
-    "build:js": "webpack --mode production",
-    "build:backends": "dash-generate-components ./src/lib/components cxdash -p package-info.json --r-prefix '' --jl-prefix '' --ignore \\.test\\.",
-    "build:backends-activated": "(. venv/bin/activate || venv\\scripts\\activate && npm run build:py_and_r)",
-    "build": "npm run build:js && npm run build:backends",
-    "build:activated": "npm run build:js && npm run build:backends-activated"
-  },
-  "author": "Original JS library and React by Isaac Neuhaus; Python and Dash JS by Todd Brett. <todd@aggregate-genius.com>",
-  "license": "MIT",
-  "dependencies": {
-    "canvasxpress": "",
-    "canvasxpress-react": "github:neuhausi/canvasxpress-react",
-    "ramda": "^0.26.1"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.5.4",
-    "@babel/plugin-proposal-object-rest-spread": "^7.5.4",
-    "@babel/preset-env": "^7.5.4",
-    "@babel/preset-react": "^7.0.0",
-    "@plotly/dash-component-plugins": "^1.2.0",
-    "@plotly/webpack-dash-dynamic-import": "^1.2.0",
-    "babel-eslint": "^10.0.2",
-    "babel-loader": "^8.0.6",
-    "copyfiles": "^2.1.1",
-    "css-loader": "^3.0.0",
-    "eslint": "^6.0.1",
-    "eslint-config-prettier": "^6.0.0",
-    "eslint-plugin-import": "^2.18.0",
-    "eslint-plugin-react": "^7.14.2",
-    "prop-types": "^15.7.2",
-    "react": "^16.8.6",
-    "react-docgen": "^4.1.1",
-    "react-dom": "^16.8.6",
-    "style-loader": "^0.23.1",
-    "styled-jsx": "^3.2.1",
-    "terser-webpack-plugin": "^2.3.0",
-    "webpack": "4.36.1",
-    "webpack-cli": "3.3.6",
-    "webpack-serve": "3.1.0"
-  },
-  "engines": {
-    "node": ">=8.11.0",
-    "npm": ">=6.1.0"
-  }
+    "name": "cxdash",
+    "version": "1.1.0",
+    "description": "CanvasXpress for Plotly Dash",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/https://github.com/docinfosci/canvasxpress-python/cxdash.git"
+    },
+    "bugs": {
+        "url": "https://github.com/https://github.com/docinfosci/canvasxpress-python/cxdash/issues"
+    },
+    "homepage": "https://github.com/https://github.com/docinfosci/canvasxpress-python/cxdash",
+    "main": "build/index.js",
+    "scripts": {
+        "start": "webpack-serve --config ./webpack.serve.config.js --open --openssl-legacy-provider",
+        "validate-init": "python _validate_init.py",
+        "prepublishOnly": "npm run validate-init",
+        "build:js": "webpack --mode production",
+        "build:backends": "dash-generate-components ./src/lib/components cxdash -p package-info.json --r-prefix '' --jl-prefix '' --ignore \\.test\\.",
+        "build:backends-activated": "(. venv/bin/activate || venv\\scripts\\activate && npm run build:py_and_r)",
+        "build": "npm run build:js && npm run build:backends",
+        "build:activated": "npm run build:js && npm run build:backends-activated"
+    },
+    "author": "Original JS library and React by Isaac Neuhaus; Python and Dash JS by Todd Brett. <todd@aggregate-genius.com>",
+    "license": "MIT",
+    "dependencies": {
+        "canvasxpress": "",
+        "canvasxpress-react": "github:neuhausi/canvasxpress-react",
+        "ramda": "^0.26.1"
+    },
+    "devDependencies": {
+        "@babel/core": "^7.5.4",
+        "@babel/plugin-proposal-object-rest-spread": "^7.5.4",
+        "@babel/preset-env": "^7.5.4",
+        "@babel/preset-react": "^7.0.0",
+        "@plotly/dash-component-plugins": "^1.2.0",
+        "@plotly/webpack-dash-dynamic-import": "^1.2.0",
+        "babel-eslint": "^10.0.2",
+        "babel-loader": "^8.0.6",
+        "copyfiles": "^2.1.1",
+        "css-loader": "^3.0.0",
+        "eslint": "^6.0.1",
+        "eslint-config-prettier": "^6.0.0",
+        "eslint-plugin-import": "^2.18.0",
+        "eslint-plugin-react": "^7.14.2",
+        "prop-types": "^15.7.2",
+        "react": "^16.8.6",
+        "react-docgen": "^4.1.1",
+        "react-dom": "^16.8.6",
+        "style-loader": "^0.23.1",
+        "styled-jsx": "^3.2.1",
+        "terser-webpack-plugin": "^2.3.0",
+        "webpack": "4.36.1",
+        "webpack-cli": "3.3.6",
+        "webpack-serve": "3.1.0"
+    },
+    "engines": {
+        "node": ">=8.11.0",
+        "npm": ">=6.1.0"
+    }
 }


### PR DESCRIPTION
* Fix for text pass-through

* Fix for popup browser chart display

* upgrade oldest support build to NodeJS 20

* Remove accidental sudo text

* Remove additional sudo text

* Alternate NodeJS installation

* Re-add node commands

* Address legacy NodeJS as part of installation of modern NodeJS

* Refine installation commands

* Update Dash build for insecure dependencies outside of project control

* Debug information

* circumvent npm exit

* Downgrade to NodeJS 16

* Fix bad text

* Apply NodeJS changes to all build editions