### PR TITLE
Streamlit integration fix continued

### DIFF
--- a/canvasxpress/render/streamlit.py
+++ b/canvasxpress/render/streamlit.py
@@ -66,7 +66,7 @@ def plot(
         application if more than one chart is being tracked. Any positive `int` of `1`
         or greater is accepted, with a default value of `1`. Values less than `1`
         are ignored.
-    :returns: An `object` or raises a `TypeError` exception if `cx` is not a CanvasXpress
+    :returns: `None` or raises a `TypeError` exception if `cx` is not a CanvasXpress
         object or list of CanvasXpress objects.
     """
 
@@ -169,4 +169,4 @@ def plot(
         .replace("@js_url@", js_url)
     )
 
-    return components.html(html, width=iframe_width, height=iframe_height)
+    components.html(html, width=iframe_width, height=iframe_height)


### PR DESCRIPTION
Remove the return value from canvasxpress.render.streamlit.plot to ensure that it works inside other Streamlit functions such as `st.write()` and `column.write()` for Streamlit column layouts.